### PR TITLE
IA-16: initial DWARF2 support

### DIFF
--- a/gcc/cfgexpand.c
+++ b/gcc/cfgexpand.c
@@ -3934,6 +3934,21 @@ convert_debug_memory_address (machine_mode mode, rtx x,
   machine_mode xmode = GET_MODE (x);
 
 #ifndef POINTERS_EXTEND_UNSIGNED
+# ifdef TARGET_ADDR_SPACE_WEIRD_P
+#  ifdef TARGET_ADDR_SPACE_CONVERT_WEIRD_MEMORY_ADDRESS
+  /* Special case for ia16-elf pointer -> address and address -> pointer
+     conversions.  Is there a better way?  */
+  if (xmode != mode && TARGET_ADDR_SPACE_WEIRD_P (as))
+  {
+    x = TARGET_ADDR_SPACE_CONVERT_WEIRD_MEMORY_ADDRESS (mode, x, as,
+                                                        false, true);
+    if (!x)
+      return x;
+    xmode = GET_MODE (x);
+  }
+  else
+#  endif
+# endif
   gcc_assert (mode == Pmode
 	      || mode == targetm.addr_space.address_mode (as));
   gcc_assert (xmode == mode || xmode == VOIDmode);

--- a/gcc/config/ia16/elf.h
+++ b/gcc/config/ia16/elf.h
@@ -67,7 +67,7 @@ extern const char *cpp_sys_defs_spec_function (int, const char **);
     "mr=msdos:-D__MSDOS__}"
 
 #define ASM_SPEC	\
-  "%{msegelf:--32-segelf}"
+  "%{msegelf:--16-segelf}"
 
 /* Our stub built-in specs now only support the building of libgcc, but can
    no longer link complete programs.  Assume that the C library (e.g.

--- a/gcc/config/ia16/ia16.c
+++ b/gcc/config/ia16/ia16.c
@@ -4510,6 +4510,14 @@ ia16_asm_function_section (tree decl, enum node_frequency freq, bool startup,
   return NULL;
 }
 
+#undef TARGET_DEBUG_UNWIND_INFO
+#define        TARGET_DEBUG_UNWIND_INFO        ia16_debug_unwind_info
+static enum unwind_info_type
+ia16_debug_unwind_info (void)
+{
+  return UI_NONE;
+}
+
 /* Output of Data */
 #undef  TARGET_ASM_BYTE_OP
 #undef  TARGET_ASM_ALIGNED_HI_OP

--- a/gcc/config/ia16/ia16.h
+++ b/gcc/config/ia16/ia16.h
@@ -578,10 +578,15 @@ extern const char * const ia16_register_prefix[],
 	fprintf (stream, "\t.p2align\t%u,,%u\n", power, max_skip)
 
 /* Controlling Debugging Information Format  */
-/* Macros Affecting All Debugging Formats  */
+#define DWARF2_DEBUGGING_INFO 1
+
 #undef PREFERRED_DEBUGGING_TYPE
-/* Macros for SDB and DWARF Output  */
-#undef DWARF2_DEBUGGING_INFO
+#define PREFERRED_DEBUGGING_TYPE DWARF2_DEBUG
+
+#define DWARF2_UNWIND_INFO 0
+
+/* POINTER_SIZE is 16-bit, but symbol addresses are 32-bit. */
+#define DWARF2_ADDR_SIZE 4
 
 #define REGISTER_TARGET_PRAGMAS() ia16_register_pragmas ()
 


### PR DESCRIPTION
This PR *technically* fixes #38 - but without a way to use it in a DOS debugger, it is arguably of little use on its own. I have worked on it for two reasons:

* Even addr2line-level line number and symbol information could be of potential use to WonderSwan emulators, which do not have any defined debugging format at this time;
* Newer GCC versions make it increasingly harder to disable debug output for a target without things breaking, so it'd be good to at least have partial debug symbol support before attempting an update again.

It does not provide call frame/unwind information - only symbol and line number information is provided, and even then, something seems broken. The matching binutils-ia16 PR is required.