### PR TITLE
Add -finstrument-functions-simple option for function instrumentation

### DIFF
--- a/gcc/common.opt
+++ b/gcc/common.opt
@@ -1520,6 +1520,10 @@ finstrument-functions
 Common Report Var(flag_instrument_function_entry_exit)
 Instrument function entry and exit with profiling calls.
 
+finstrument-functions-simple
+Common Report Var(flag_instrument_function_entry_exit_simple)
+Don't generate code to push arguments to instrument profiling functions.
+
 finstrument-functions-exclude-function-list=
 Common RejectNegative Joined
 -finstrument-functions-exclude-function-list=name,...  Do not instrument listed functions.


### PR DESCRIPTION
Adds `-finstrument-functions-simple` option, which when used with `-finstrument-functions` generates simpler instrumentation code at the prologue and epilogue of each compiled function. 

Originally requested in #111.

The simpler instrumentation code generated is similar to when using `-finstrument-functions`, and generates code to call `__cyg_profile_func_enter` and `__cyg_profile_func_exit` at function entry and exit, but omits generating the code for each profiling function's two arguments (the calling function's address and call site address). The simpler instrumentation code is being used in ELKS for two reasons: 1) with symbol tables now available included within the a.out file, there is no longer the need to generate code for the calling function address and call site, as both can be computed using the symbol table and `__builtin_return_address`, and `__builtin_frame_address`. 2) Debugging is complicated when just using `-finstrument-functions` as the code generated for the two arguments changes the registers used during function compilation and can completely change the code generated for the function. With this enhancement, the compiled function code is identical, with only the addition of the two calls to the profiling functions at entry and exit.

Care has been taken coding this enhancement to ensure that the compiler generates exactly the same code unless `-finstrument-functions` and `-finstrument-functions-simple` are set.
