### PR TITLE
Add -maout-symtab option to add symbol table to a.out file

### DIFF
--- a/gcc/config/ia16/elf.h
+++ b/gcc/config/ia16/elf.h
@@ -102,4 +102,4 @@ extern const char *cpp_sys_defs_spec_function (int, const char **);
 		   "%{mhandle-non-i186} %{mhandle-non-i286} " \
 		   "%{mdosx} %{mdosx32} " \
 		   "%{maout} %{maout-total=*} %{maout-chmem=*} " \
-		   "%{maout-stack=*} %{maout-heap=*}" }
+		   "%{maout-stack=*} %{maout-heap=*} %{maout-symtab}" }

--- a/gcc/config/ia16/ia16.opt
+++ b/gcc/config/ia16/ia16.opt
@@ -258,6 +258,10 @@ maout-heap=
 Target RejectNegative Joined UInteger
 Set the size of the heap for ELKS OS executables.
 
+maout-symtab
+Target RejectNegative
+Add symbol table to output file.
+
 maout-total=
 Target RejectNegative Joined UInteger Warn(%<-maout-total=%> is deprecated; use %<-maout-stack=%> and %<-maout-heap=%>)
 Deprecated.  Set the top of the data segment for ELKS executables.


### PR DESCRIPTION
Adds `-maout-symtab` to `ia16-elf-gcc` which runs `elf2elks --symtab`. Discussed in #131 and will be combined with `r-elks.spec` file update in ELKS https://github.com/jbruchon/elks/pull/1519.