### PR TITLE
IA-16: partially fix/workaround libgcc errors on -mno-assume-ss-data-segment

### DIFF
--- a/libgcc/config/ia16/ashlsi3.S
+++ b/libgcc/config/ia16/ashlsi3.S
@@ -29,7 +29,7 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 __ashlsi3:
 #ifndef __IA16_CMODEL_IS_FAR_TEXT
 # ifdef __IA16_CALLCVT_CDECL
-#   ifdef __OPTIMIZE_SIZE__
+#  if defined __OPTIMIZE_SIZE__ || defined __IA16_FEATURE_ATTRIBUTE_NO_ASSUME_SS_DATA
 	popw	%bx
 	popw	%ax
 	popw	%dx
@@ -38,12 +38,12 @@ __ashlsi3:
 	pushw	%dx
 	pushw	%ax
 	pushw	%bx
-#   else
+#  else
 	movw	%sp,	%bx
 	movw	2(%bx),	%ax
 	movw	4(%bx),	%dx
 	movb	6(%bx),	%cl
-#   endif
+#  endif
 # elif defined __IA16_CALLCVT_STDCALL
 	popw	%bx
 	popw	%ax
@@ -54,16 +54,27 @@ __ashlsi3:
 #else
 # ifdef __IA16_CALLCVT_CDECL
 	movw	%sp,	%bx
+#  ifdef __IA16_FEATURE_ATTRIBUTE_NO_ASSUME_SS_DATA
+	movw	%ss:4(%bx),	%ax
+	movw	%ss:6(%bx),	%dx
+	movb	%ss:8(%bx),	%cl
+#  else
 	movw	4(%bx),	%ax
 	movw	6(%bx),	%dx
 	movb	8(%bx),	%cl
+#   endif
 # elif defined __IA16_CALLCVT_STDCALL
 	popw	%dx
 	popw	%cx
 	popw	%ax
 	movw	%sp,	%bx
+#  ifdef __IA16_FEATURE_ATTRIBUTE_NO_ASSUME_SS_DATA
+	xchgw	%dx,	%ss:(%bx)
+	xchgw	%cx,	%ss:2(%bx)
+#  else
 	xchgw	%dx,	(%bx)
 	xchgw	%cx,	2(%bx)
+#  endif
 # endif
 #endif
 	andw	$0x1f,	%cx

--- a/libgcc/config/ia16/ia16-divmodsi.h
+++ b/libgcc/config/ia16/ia16-divmodsi.h
@@ -45,22 +45,37 @@ __modsi3:
 #ifndef __IA16_CMODEL_IS_FAR_TEXT
 # if defined __IA16_CALLCVT_CDECL
 	movw	%sp,	%bx
+#  ifdef __IA16_FEATURE_ATTRIBUTE_NO_ASSUME_SS_DATA
+	movw	%ss:2(%bx),	%ax
+	movw	%ss:4(%bx),	%dx
+	movw	%ss:8(%bx),	%cx
+	movw	%ss:6(%bx),	%bx
+#  else
 	movw	2(%bx),	%ax
 	movw	4(%bx),	%dx
 	movw	8(%bx),	%cx
 	movw	6(%bx),	%bx
+#  endif
 # elif defined __IA16_CALLCVT_STDCALL
 	/* Pop arguments but "push" the return address back.  */
 	popw	%cx
 	movw	%sp,	%bx
+#  ifdef __IA16_FEATURE_ATTRIBUTE_NO_ASSUME_SS_DATA
+	xchgw	%cx,	%ss:6(%bx)
+#  else
 	xchgw	%cx,	6(%bx)
+#  endif
 	popw	%ax
 	popw	%dx
 	popw	%bx
 # elif defined __IA16_CALLCVT_REGPARMCALL
 	popw	%cx
 	movw	%sp,	%bx
+#  ifdef __IA16_FEATURE_ATTRIBUTE_NO_ASSUME_SS_DATA
+	xchgw	%cx,	%ss:2(%bx)
+#  else
 	xchgw	%cx,	2(%bx)
+#  endif
 	popw	%bx
 # else
 #   error "unknown calling convention!"
@@ -84,14 +99,26 @@ __modsi3:
 #else
 # if defined __IA16_CALLCVT_CDECL || defined __IA16_CALLCVT_STDCALL
 	movw	%sp,	%bx
+#  ifdef __IA16_FEATURE_ATTRIBUTE_NO_ASSUME_SS_DATA
+	movw	%ss:4(%bx),	%ax
+	movw	%ss:6(%bx),	%dx
+	movw	%ss:10(%bx),	%cx
+	movw	%ss:8(%bx),	%bx
+#  else
 	movw	4(%bx),	%ax
 	movw	6(%bx),	%dx
 	movw	10(%bx), %cx
 	movw	8(%bx),	%bx
+#  endif
 # elif defined __IA16_CALLCVT_REGPARMCALL
 	movw	%sp,	%bx
-	movw	6(%bx), %cx
+#  ifdef __IA16_FEATURE_ATTRIBUTE_NO_ASSUME_SS_DATA
+	movw	%ss:6(%bx),	%cx
+	movw	%ss:4(%bx),	%bx
+#  else
+	movw	6(%bx),	%cx
 	movw	4(%bx),	%bx
+#  endif
 # else
 #   error "unknown calling convention!"
 # endif

--- a/libgcc/config/ia16/lshrsi3.S
+++ b/libgcc/config/ia16/lshrsi3.S
@@ -29,7 +29,7 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 __lshrsi3:
 #ifndef __IA16_CMODEL_IS_FAR_TEXT
 # ifdef __IA16_CALLCVT_CDECL
-#   ifdef __OPTIMIZE_SIZE__
+#  if defined __OPTIMIZE_SIZE__ || defined __IA16_FEATURE_ATTRIBUTE_NO_ASSUME_SS_DATA
 	popw	%bx
 	popw	%ax
 	popw	%dx
@@ -38,12 +38,12 @@ __lshrsi3:
 	pushw	%dx
 	pushw	%ax
 	pushw	%bx
-#   else
+#  else
 	movw	%sp,	%bx
 	movw	2(%bx),	%ax
 	movw	4(%bx),	%dx
 	movb	6(%bx),	%cl
-#   endif
+#  endif
 # elif defined __IA16_CALLCVT_STDCALL
 	popw	%bx
 	popw	%ax
@@ -54,16 +54,27 @@ __lshrsi3:
 #else
 # ifdef __IA16_CALLCVT_CDECL
 	movw	%sp,	%bx
+#  ifdef __IA16_FEATURE_ATTRIBUTE_NO_ASSUME_SS_DATA
+	movw	%ss:4(%bx),	%ax
+	movw	%ss:6(%bx),	%dx
+	movb	%ss:8(%bx),	%cl
+#  else
 	movw	4(%bx),	%ax
 	movw	6(%bx),	%dx
 	movb	8(%bx),	%cl
+#   endif
 # elif defined __IA16_CALLCVT_STDCALL
 	popw	%dx
 	popw	%cx
 	popw	%ax
 	movw	%sp,	%bx
+#  ifdef __IA16_FEATURE_ATTRIBUTE_NO_ASSUME_SS_DATA
+	xchgw	%dx,	%ss:(%bx)
+	xchgw	%cx,	%ss:2(%bx)
+#  else
 	xchgw	%dx,	(%bx)
 	xchgw	%cx,	2(%bx)
+#  endif
 # endif
 #endif
 	andw	$0x1f,	%cx

--- a/libgcc/config/ia16/t-ia16
+++ b/libgcc/config/ia16/t-ia16
@@ -87,3 +87,12 @@ $(patsubst $(srcdir)/config/ia16/%.S,%$(objext),$(LIB2ADD)) : \
 	     $(srcdir)/config/ia16/ia16-divmodsi.h \
 	     $(srcdir)/config/ia16/ia16-far-call-thunks-imm.h \
 	     $(srcdir)/config/ia16/ia16-far-call-pop-thunks-imm.h
+
+# FIXME: The following functionality fails to compile with -mno-callee-assume-ss-data-segment.
+ifeq (-mno-callee-assume-ss-data-segment,$(filter -mno-callee-assume-ss-data-segment,$(MULTIFLAGS)))
+LIB2ADDEH =
+LIB2FUNCS_EXCLUDE += _umoddi3
+FPBIT =
+DPBIT =
+TPBIT =
+endif


### PR DESCRIPTION
Finally, an issue which I could fix with my skill level!...

Based on limited testing, this seems to be sufficient for a minimal IA-16 libgcc to compile and function when DS != SS. Unfortunately, some code had to be forcibly disabled due to ICEs and/or other compilation issues.

For context, the flags I'm using:

```
        make all-target-libgcc \
                CFLAGS_FOR_TARGET="-O2 -march=v30mz -mtune=v30mz -mregparmcall -mcmodel=small -mno-callee-assume-ss-data-segment -msegelf" \
                MULTIFLAGS="-march=v30mz -mtune=v30mz -mregparmcall -mcmodel=small -mno-callee-assume-ss-data-segment -msegelf"
```